### PR TITLE
Update installing-henkaku.md

### DIFF
--- a/docs/installing-henkaku.md
+++ b/docs/installing-henkaku.md
@@ -13,7 +13,7 @@ In addition to running the HENkaku exploit, we will also enable access to "unsaf
 The "VitaDeploy" application will also be installed to your home screen. VitaDeploy makes installing apps, plugins, and custom firmwares simple and includes many useful tools and utilites.
 
 ::: tip
-If you have a PS Vita 1000, you must also have an official Sony memory card (of any size) to follow this guide. This restriction does not apply to the PS Vita 2000 or PS TV as those devices have a built-in memory card.
+If you have a PS Vita 1000, you must also have an official Sony memory card (or [first unlock its internal memory](creating-an-internal-memory-card.html)) to follow this guide. This restriction does not apply to the PS Vita 2000 or PS TV as those devices have preconfigured internal storage.
 :::
 
 ### What You Need


### PR DESCRIPTION
 Updated installing-henkaku.md

1) Added a reference to imcunlock in the tip section for PS Vita 1000 owners. 

2) Changed: "This restriction does not apply to the PS Vita 2000 or PS TV as those devices have a -- built-in memory card --." to
Now: "This restriction does not apply to the PS Vita 2000 or PS TV as those devices have  -- preconfigured internal storage -- ."

3) Changed grammatical error as pointed out by Paddel (it's vs its)

:)